### PR TITLE
Update hub transport protocols to avoid duplicate characters.

### DIFF
--- a/server/src/Shadowrun.LocalService.Core/Protocols/APlayTcpStub.cs
+++ b/server/src/Shadowrun.LocalService.Core/Protocols/APlayTcpStub.cs
@@ -2436,11 +2436,9 @@ namespace Shadowrun.LocalService.Core.Protocols
                                     var previousHubId = ResolveParticipantHubId(previousParticipant, null);
                                     var currentParticipantHubId = ResolveParticipantHubId(currentParticipant, routedHubId);
 
-                                    var shouldBroadcastAdd = transition != null
-                                        ? transition.JoinUpdate != null
-                                        : previousParticipant == null
-                                            || !string.Equals(previousHubId, routedHubId, StringComparison.OrdinalIgnoreCase)
-                                            || !string.Equals(previousParticipant.CharacterId, routedCharacterIdentifier, StringComparison.OrdinalIgnoreCase);
+                                    var shouldBroadcastAdd = previousParticipant == null
+                                        || !string.Equals(previousHubId, currentParticipantHubId, StringComparison.OrdinalIgnoreCase)
+                                        || !string.Equals(previousParticipant.CharacterId, currentParticipant != null ? currentParticipant.CharacterId : routedCharacterIdentifier, StringComparison.OrdinalIgnoreCase);
 
                                     if (transition != null && transition.LeaveUpdate != null && !IsNullOrWhiteSpace(transition.LeaveUpdate.RemovedCharacter))
                                     {
@@ -2456,9 +2454,16 @@ namespace Shadowrun.LocalService.Core.Protocols
 
                                     if (currentParticipant != null && !IsNullOrWhiteSpace(currentParticipantHubId))
                                     {
-                                        // Force a fresh hub-ready/replay cycle for this peer on story-hub requests.
-                                        // This is needed when the client returns from mission but hub/character IDs are unchanged.
-                                        ClearHubAnnouncementsForPeerHub(peer, currentParticipantHubId);
+                                        var isSameHubSameCharacter = previousParticipant != null
+                                            && string.Equals(previousHubId, currentParticipantHubId, StringComparison.OrdinalIgnoreCase)
+                                            && string.Equals(previousParticipant.CharacterId, currentParticipant.CharacterId, StringComparison.OrdinalIgnoreCase);
+
+                                        // Preserve per-peer hub announcement/readiness state on same-hub refresh.
+                                        // Clearing this forces roster replay on next move and can duplicate remote avatars.
+                                        if (!isSameHubSameCharacter)
+                                        {
+                                            ClearHubAnnouncementsForPeerHub(peer, currentParticipantHubId);
+                                        }
 
                                         if (shouldBroadcastAdd)
                                         {
@@ -2704,11 +2709,9 @@ namespace Shadowrun.LocalService.Core.Protocols
                                         var previousHubId = ResolveParticipantHubId(previousParticipant, null);
                                         var currentParticipantHubId = ResolveParticipantHubId(currentParticipant, effectiveHubId);
 
-                                            var shouldBroadcastAdd = transition != null
-                                                ? transition.JoinUpdate != null
-                                                : previousParticipant == null
-                                                    || !string.Equals(previousHubId, effectiveHubId, StringComparison.OrdinalIgnoreCase)
-                                                    || !string.Equals(previousParticipant.CharacterId, currentCharacterIdentifier, StringComparison.OrdinalIgnoreCase);
+                                            var shouldBroadcastAdd = previousParticipant == null
+                                                || !string.Equals(previousHubId, currentParticipantHubId, StringComparison.OrdinalIgnoreCase)
+                                                || !string.Equals(previousParticipant.CharacterId, currentParticipant != null ? currentParticipant.CharacterId : currentCharacterIdentifier, StringComparison.OrdinalIgnoreCase);
 
                                             if (transition != null && transition.LeaveUpdate != null && !IsNullOrWhiteSpace(transition.LeaveUpdate.RemovedCharacter))
                                             {
@@ -2724,9 +2727,16 @@ namespace Shadowrun.LocalService.Core.Protocols
 
                                         if (currentParticipant != null && !IsNullOrWhiteSpace(currentParticipantHubId))
                                         {
-                                            // Force a fresh hub-ready/replay cycle for this peer on story-hub requests.
-                                            // This is needed when the client returns from mission but hub/character IDs are unchanged.
-                                            ClearHubAnnouncementsForPeerHub(peer, currentParticipantHubId);
+                                            var isSameHubSameCharacter = previousParticipant != null
+                                                && string.Equals(previousHubId, currentParticipantHubId, StringComparison.OrdinalIgnoreCase)
+                                                && string.Equals(previousParticipant.CharacterId, currentParticipant.CharacterId, StringComparison.OrdinalIgnoreCase);
+
+                                            // Preserve per-peer hub announcement/readiness state on same-hub refresh.
+                                            // Clearing this forces roster replay on next move and can duplicate remote avatars.
+                                            if (!isSameHubSameCharacter)
+                                            {
+                                                ClearHubAnnouncementsForPeerHub(peer, currentParticipantHubId);
+                                            }
 
                                             if (shouldBroadcastAdd)
                                             {

--- a/server/src/Shadowrun.LocalService.Core/Protocols/PartyHubFollowRegistry.cs
+++ b/server/src/Shadowrun.LocalService.Core/Protocols/PartyHubFollowRegistry.cs
@@ -54,6 +54,36 @@ namespace Shadowrun.LocalService.Core.Protocols
             }
         }
 
+        public static void ClearMembersFollowingHost(Guid hostAccountId)
+        {
+            if (hostAccountId == Guid.Empty)
+            {
+                return;
+            }
+
+            lock (LockObj)
+            {
+                if (HostByMember.Count == 0)
+                {
+                    return;
+                }
+
+                var membersToClear = new List<Guid>();
+                foreach (var kvp in HostByMember)
+                {
+                    if (kvp.Value == hostAccountId)
+                    {
+                        membersToClear.Add(kvp.Key);
+                    }
+                }
+
+                for (var i = 0; i < membersToClear.Count; i++)
+                {
+                    HostByMember.Remove(membersToClear[i]);
+                }
+            }
+        }
+
         public static void ClearForGroup(IEnumerable<Guid> memberAccountIds)
         {
             if (memberAccountIds == null)

--- a/server/src/Shadowrun.LocalService.Core/Protocols/PhotonProxyTcpStub.Operations.cs
+++ b/server/src/Shadowrun.LocalService.Core/Protocols/PhotonProxyTcpStub.Operations.cs
@@ -606,18 +606,20 @@ namespace Shadowrun.LocalService.Core.Protocols
                 {
                     var req = DeserializeMessage<RemoveGroupMemberRequest>(requestPayload);
                     var result = "GroupNotExists";
+                    var removedAccountId = req != null && req.MemberId != Guid.Empty ? req.MemberId : state.AccountId;
                     try
                     {
                         result = _chatAndFriends.RemoveGroupMember(state.AccountId, req != null ? req.GroupId : 0, req != null ? req.MemberId : Guid.Empty);
                         if (string.Equals(result, "Success", StringComparison.OrdinalIgnoreCase)
                             || string.Equals(result, "Ok", StringComparison.OrdinalIgnoreCase))
                         {
-                            if (req != null && req.MemberId != Guid.Empty)
+                            if (removedAccountId != Guid.Empty)
                             {
-                                PartyHubFollowRegistry.ClearForMember(req.MemberId);
+                                PartyHubFollowRegistry.ClearForMember(removedAccountId);
+                                PartyHubFollowRegistry.ClearMembersFollowingHost(removedAccountId);
                             }
 
-                            if (req == null || req.MemberId == Guid.Empty || req.MemberId == state.AccountId)
+                            if (removedAccountId == Guid.Empty || removedAccountId == state.AccountId)
                             {
                                 PartyHubFollowRegistry.ClearForMember(state.AccountId);
                             }


### PR DESCRIPTION
Prevent duplicate characters, as well as incorrect hub returns.